### PR TITLE
chore: strengthen rbac board validation

### DIFF
--- a/RBAC_GUIDE.md
+++ b/RBAC_GUIDE.md
@@ -36,6 +36,7 @@ board: "ai"
 ```
 
 `board`가 없으면 `default_board`를 사용합니다.
+`board`를 지정했는데 `rbac.config.json`에 없는 값이면 PR이 실패합니다.
 
 ## GitHub 설정(필수)
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm run preview
 - `/.github/workflows/rbac.yml`이 PR 변경 파일을 검사합니다.
 - 게시판별 편집 권한은 `/.github/rbac.config.json`에서 관리합니다.
 - 상세 운영 방법은 `RBAC_GUIDE.md`를 참고합니다.
+- 로컬 점검은 `npm run check:rbac`로 실행합니다.
 
 ## 검색 엔진 색인
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,7 @@
 ## 현재
 
 - Git 기반 RBAC 1차 적용 완료: `CODEOWNERS`, PR 권한검사 워크플로(`.github/workflows/rbac.yml`), 보드별 권한 설정 파일(`.github/rbac.config.json`), 운영 문서(`RBAC_GUIDE.md`)를 추가함.
+- RBAC 검증 강화: 노트 frontmatter `board`가 미등록 값이면 PR을 실패시키고, 로컬 검증 스크립트 `npm run check:rbac`를 추가함.
 - UI 기본 문구를 한국어로 전환하고 네비게이션/섹션 라벨 KR/EN 토글을 추가함.
 - UI를 프리미엄 에디토리얼 톤으로 리디자인하고 히어로/카드/검색 스타일을 개선함.
 - 히어로 아트워크, 노트 상세 매거진 레이아웃, 절제된 모션을 적용함.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "check:rbac": "node scripts/check-rbac.mjs",
     "postbuild": "pagefind --site dist --exclude-selectors .no-search",
     "format": "prettier --write ."
   },

--- a/scripts/check-rbac.mjs
+++ b/scripts/check-rbac.mjs
@@ -80,20 +80,22 @@ const readFileForBoard = (filePath) => {
   return readFileAtRef(baseSha, filePath);
 };
 
-const resolveBoard = (filePath) => {
+const resolveBoardMeta = (filePath) => {
   const fallbackBoard = config.default_board || "general";
   const text = readFileForBoard(filePath);
-  if (!text) return fallbackBoard;
+  if (!text) return { board: fallbackBoard.toLowerCase(), explicit: false };
 
   const trimmed = text.trimStart();
-  if (!trimmed.startsWith("---")) return fallbackBoard;
+  if (!trimmed.startsWith("---")) return { board: fallbackBoard.toLowerCase(), explicit: false };
 
   const match = trimmed.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return fallbackBoard;
+  if (!match) return { board: fallbackBoard.toLowerCase(), explicit: false };
 
   const frontmatter = match[1];
   const boardMatch = frontmatter.match(/^board:\s*["']?([a-zA-Z0-9_-]+)["']?\s*$/m);
-  return boardMatch ? boardMatch[1].toLowerCase() : fallbackBoard;
+  return boardMatch
+    ? { board: boardMatch[1].toLowerCase(), explicit: true }
+    : { board: fallbackBoard.toLowerCase(), explicit: false };
 };
 
 const getChangedFiles = () => {
@@ -112,6 +114,8 @@ const boardEditors = new Map(
     new Set(toArray(users).map(normalizeUser).filter(Boolean))
   ])
 );
+const defaultBoard = String(config.default_board || "general").toLowerCase();
+const allowedBoards = new Set([defaultBoard, ...boardEditors.keys()]);
 const noteMatchers = toArray(config.note_paths).map(globToRegex);
 const adminMatchers = toArray(config.admin_only_paths).map(globToRegex);
 
@@ -150,9 +154,18 @@ changedFiles.forEach((filePath) => {
 
   if (isAdmin) return;
 
-  const board = resolveBoard(filePath);
+  const boardMeta = resolveBoardMeta(filePath);
+  if (boardMeta.explicit && !allowedBoards.has(boardMeta.board)) {
+    violations.push({
+      filePath,
+      reason: `unknown board "${boardMeta.board}" (configure in .github/rbac.config.json)`
+    });
+    return;
+  }
+
+  const board = boardMeta.board;
   const allowedEditors =
-    boardEditors.get(board) || boardEditors.get(String(config.default_board || "general").toLowerCase());
+    boardEditors.get(board) || boardEditors.get(defaultBoard);
   if (!allowedEditors || !allowedEditors.has(actor)) {
     violations.push({
       filePath,


### PR DESCRIPTION
## Summary\n- fail PR when note frontmatter board is unknown\n- add local command: npm run check:rbac\n- align docs and roadmap for the updated RBAC behavior\n\n## Validation\n- node --check scripts/check-rbac.mjs\n- npm run build\n