### PR TITLE
fix(ui): responsive stability across notebook and large displays

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,7 +16,7 @@
   --header-height: 82px;
   --shadow: 0 32px 80px rgba(9, 16, 22, 0.2);
   --shadow-soft: 0 16px 42px rgba(9, 16, 22, 0.14);
-  --max: 1200px;
+  --max: 1240px;
   --font-body: "IBM Plex Sans KR", "Apple SD Gothic Neo", sans-serif;
   --font-display: "Song Myung", serif;
   --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -69,7 +69,7 @@ img {
 .container {
   max-width: var(--max);
   margin: 0 auto;
-  padding: 0 32px;
+  padding: 0 clamp(16px, 2.2vw, 32px);
 }
 
 .page {
@@ -108,8 +108,8 @@ img {
 .site-header::after {
   content: "";
   position: absolute;
-  left: 32px;
-  right: 32px;
+  left: clamp(16px, 2.2vw, 32px);
+  right: clamp(16px, 2.2vw, 32px);
   bottom: 0;
   height: 1px;
   background: linear-gradient(90deg, transparent, rgba(165, 109, 46, 0.45), rgba(24, 74, 89, 0.45), transparent);
@@ -318,6 +318,10 @@ img {
   grid-template-columns: minmax(0, 1.16fr) minmax(0, 0.84fr);
   gap: 22px;
   align-items: start;
+}
+
+.hero-split > * {
+  min-width: 0;
 }
 
 .hero-copy {
@@ -531,6 +535,7 @@ img {
 .hero-panel {
   display: grid;
   gap: 14px;
+  align-content: start;
 }
 
 .hero-panel-card {
@@ -542,6 +547,7 @@ img {
   transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
   position: relative;
   overflow: hidden;
+  min-width: 0;
 }
 
 .hero-panel-card:hover {
@@ -574,6 +580,7 @@ img {
   border: 1px solid rgba(16, 33, 44, 0.12);
   display: grid;
   gap: 4px;
+  min-width: 0;
 }
 
 .hero-stat-value {
@@ -610,6 +617,7 @@ img {
   grid-template-columns: 32px 1fr;
   gap: 10px;
   align-items: start;
+  min-width: 0;
 }
 
 .workflow-preview-index {
@@ -638,6 +646,7 @@ img {
   color: #4d6270;
   font-size: 0.82rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .command-preview {
@@ -989,6 +998,7 @@ img {
 
 .path-grid {
   display: grid;
+  grid-template-columns: 1fr;
   gap: 14px;
 }
 
@@ -1004,6 +1014,7 @@ img {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   position: relative;
   overflow: hidden;
+  min-width: 0;
 }
 
 .path-card:hover {
@@ -1712,9 +1723,81 @@ img {
   }
 }
 
+@media (min-width: 1440px) {
+  :root {
+    --max: 1360px;
+  }
+
+  .hero-shell {
+    padding: 64px 56px;
+  }
+
+  .hero-split {
+    grid-template-columns: minmax(0, 1.2fr) minmax(360px, 0.8fr);
+    gap: 28px;
+  }
+
+  .path-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .note-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .workspace-shell {
+    grid-template-columns: 360px minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 1800px) {
+  :root {
+    --max: 1480px;
+  }
+
+  .note-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1280px) {
+  .hero-shell {
+    padding: 48px 36px;
+  }
+
+  .hero-split {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr);
+    gap: 18px;
+  }
+
+  .hero-title-emphasis {
+    font-size: clamp(2.4rem, 4.8vw, 3.8rem);
+  }
+
+  .hero-panel-card {
+    padding: 16px;
+  }
+
+  .workspace-toolbar-filters {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 1024px) {
   .hero-split {
     grid-template-columns: 1fr;
+  }
+
+  .hero-shell {
+    padding: 44px 30px;
+  }
+
+  .hero-panel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-panel .command-preview {
+    grid-column: 1 / -1;
   }
 
   .hero-signal-rail {
@@ -1877,6 +1960,7 @@ img {
   }
 
   .hero-panel {
+    grid-template-columns: 1fr;
     gap: 14px;
   }
 


### PR DESCRIPTION
## 요약\n- 노트북/대형 해상도 대응 브레이크포인트를 추가했습니다.\n- 홈 히어로 그리드와 패널 폭 계산을 안정화했습니다.\n- 중간 해상도(<=1280)에서 과밀했던 필터/패널 레이아웃을 완화했습니다.\n- 큰 화면에서 컨테이너/노트 그리드/경로 카드 배치를 확장했습니다.\n\n## 검증\n- npm run build\n