### PR TITLE
fix(ui): stabilize responsive layout for laptop and large displays

### DIFF
--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -82,9 +82,10 @@ const isActive = (href) => (href === "/" ? pathname === "/" : pathname.startsWit
   const toggle = document.querySelector("[data-menu-toggle]");
   const nav = document.getElementById("site-nav");
   const backdrop = document.querySelector("[data-menu-backdrop]");
+  const navCollapseQuery = "(max-width: 1120px)";
 
   if (toggle && nav) {
-    const isMobile = () => window.innerWidth <= 768;
+    const isMobile = () => window.matchMedia(navCollapseQuery).matches;
     toggle.setAttribute("data-ready", "true");
     nav.dataset.collapsible = "true";
     nav.setAttribute("aria-hidden", isMobile() ? "true" : "false");

--- a/src/pages/workspace/index.astro
+++ b/src/pages/workspace/index.astro
@@ -96,26 +96,32 @@ const t = (key, vars) => translate(DEFAULT_LANG, key, vars);
             </label>
           </div>
           <div class="workspace-toolbar-filters">
-            <label for="workspace-note-search" data-i18n="workspace.toolbar.searchLabel">
-              {t("workspace.toolbar.searchLabel")}
-            </label>
-            <input
-              id="workspace-note-search"
-              type="search"
-              class="workspace-input"
-              data-note-search
-              placeholder={t("workspace.toolbar.searchPlaceholder")}
-              data-i18n="workspace.toolbar.searchPlaceholder"
-              data-i18n-attr="placeholder"
-            />
-            <label for="workspace-note-filter" data-i18n="workspace.toolbar.filterLabel">
-              {t("workspace.toolbar.filterLabel")}
-            </label>
-            <select id="workspace-note-filter" class="workspace-input" data-note-filter></select>
-            <label for="workspace-board-filter" data-i18n="workspace.toolbar.boardFilterLabel">
-              {t("workspace.toolbar.boardFilterLabel")}
-            </label>
-            <select id="workspace-board-filter" class="workspace-input" data-board-filter></select>
+            <div class="workspace-filter-field">
+              <label for="workspace-note-search" data-i18n="workspace.toolbar.searchLabel">
+                {t("workspace.toolbar.searchLabel")}
+              </label>
+              <input
+                id="workspace-note-search"
+                type="search"
+                class="workspace-input"
+                data-note-search
+                placeholder={t("workspace.toolbar.searchPlaceholder")}
+                data-i18n="workspace.toolbar.searchPlaceholder"
+                data-i18n-attr="placeholder"
+              />
+            </div>
+            <div class="workspace-filter-field">
+              <label for="workspace-note-filter" data-i18n="workspace.toolbar.filterLabel">
+                {t("workspace.toolbar.filterLabel")}
+              </label>
+              <select id="workspace-note-filter" class="workspace-input" data-note-filter></select>
+            </div>
+            <div class="workspace-filter-field">
+              <label for="workspace-board-filter" data-i18n="workspace.toolbar.boardFilterLabel">
+                {t("workspace.toolbar.boardFilterLabel")}
+              </label>
+              <select id="workspace-board-filter" class="workspace-input" data-board-filter></select>
+            </div>
           </div>
         </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,6 +130,10 @@ img {
   backdrop-filter: blur(18px);
 }
 
+.header-inner > * {
+  min-width: 0;
+}
+
 .logo {
   font-family: var(--font-display);
   font-size: 1.6rem;
@@ -144,11 +148,13 @@ img {
   border-radius: 999px;
   border: 1px solid rgba(17, 26, 31, 0.09);
   background: rgba(255, 255, 255, 0.58);
+  min-width: 0;
 }
 
 .nav-list {
   list-style: none;
   display: flex;
+  flex-wrap: nowrap;
   gap: 4px;
   padding: 0;
   margin: 0;
@@ -794,7 +800,7 @@ img {
 
 .note-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 20px;
 }
 
@@ -998,7 +1004,7 @@ img {
 
 .path-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
 }
 
@@ -1355,6 +1361,10 @@ img {
   gap: 18px;
 }
 
+.workspace-shell > * {
+  min-width: 0;
+}
+
 .workspace-sidebar,
 .workspace-main {
   border-radius: 20px;
@@ -1477,13 +1487,30 @@ img {
 }
 
 .workspace-toolbar-filters {
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  align-items: end;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: start;
+  gap: 12px;
+}
+
+.workspace-filter-field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
 }
 
 .workspace-toolbar-filters input,
 .workspace-toolbar-filters select {
   min-height: 42px;
+}
+
+.workspace-toolbar-actions > * {
+  flex: 1 1 170px;
+  min-width: 0;
+}
+
+.workspace-toolbar-actions .workspace-btn,
+.workspace-toolbar-actions .workspace-import-btn {
+  width: 100%;
 }
 
 .workspace-status {
@@ -1518,6 +1545,10 @@ img {
   display: grid;
   grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
   gap: 16px;
+}
+
+.workspace-content-grid > * {
+  min-width: 0;
 }
 
 .workspace-list-panel,
@@ -1560,6 +1591,7 @@ img {
 .workspace-note-head h3 {
   margin: 0;
   font-size: 1rem;
+  overflow-wrap: anywhere;
 }
 
 .workspace-note-head span {
@@ -1572,6 +1604,7 @@ img {
   color: #465862;
   font-size: 0.9rem;
   line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 
 .workspace-note-meta {
@@ -1665,6 +1698,7 @@ img {
   color: #1f3742;
   font-weight: 700;
   cursor: pointer;
+  overflow-wrap: anywhere;
 }
 
 .workspace-tree-count {
@@ -1778,58 +1812,12 @@ img {
     padding: 16px;
   }
 
-  .workspace-toolbar-filters {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 1024px) {
-  .hero-split {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-shell {
-    padding: 44px 30px;
-  }
-
-  .hero-panel {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .hero-panel .command-preview {
-    grid-column: 1 / -1;
-  }
-
-  .hero-signal-rail {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .hero-stats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .note-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .note-toc {
-    position: static;
-  }
-
   .workspace-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .workspace-content-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .workspace-toolbar-filters {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1120px) {
   body.menu-open {
     overflow: hidden;
   }
@@ -1886,6 +1874,76 @@ img {
     pointer-events: auto;
   }
 
+  .nav-list {
+    flex-direction: column;
+    gap: 6px;
+    padding: 4px;
+  }
+
+  .nav-list a {
+    display: block;
+    padding: 10px 12px;
+  }
+
+  .lang-switch {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .hero-split {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-shell {
+    padding: 44px 30px;
+  }
+
+  .hero-panel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-panel .command-preview {
+    grid-column: 1 / -1;
+  }
+
+  .hero-signal-rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .note-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .path-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .note-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .note-toc {
+    position: static;
+  }
+
+  .workspace-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-toolbar-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
   .hero {
     padding: 50px 0 30px;
   }
@@ -1987,22 +2045,6 @@ img {
 
   .note-hero-card {
     padding: 24px;
-  }
-
-  .nav-list {
-    flex-direction: column;
-    gap: 6px;
-    padding: 4px;
-  }
-
-  .nav-list a {
-    display: block;
-    padding: 10px 12px;
-  }
-
-  .lang-switch {
-    grid-column: 1 / -1;
-    justify-self: start;
   }
 
   .hero-stats {


### PR DESCRIPTION
## Summary
- harden responsive behavior for notebook and large displays
- move header collapse breakpoint to 1120px to prevent nav wrapping breakage
- refactor workspace filters into grouped fields and improve action/button wrapping
- add overflow-safe styles and rebalance note/path/workspace grids by breakpoint

## Validation
- npm run build
- local dev server response check on http://127.0.0.1:4322 and /workspace/